### PR TITLE
Centralize file paths

### DIFF
--- a/file_paths.yaml
+++ b/file_paths.yaml
@@ -1,0 +1,27 @@
+# Centralized file paths used across the project
+# Update these paths to match your local environment
+
+dark_image: "C:/Users/Kenpo/OneDrive/Research/Rigaku XRD/ORNL.07.25.2024/Varying/Images/darkImg.osc"
+osc_files:
+  - "C:/Users/Kenpo/OneDrive - University of Missouri/David and Paul/PbI2/Catalog/3.18.24/B_4deg_2m.osc"
+  - "C:/Users/Kenpo/OneDrive/Research/Rigaku XRD/ORNL.07.25.2024/Varying/Images/Bi2Se3_10d_5m.osc"
+  - "C:/Users/Kenpo/OneDrive/Research/Rigaku XRD/ORNL.07.25.2024/Varying/Images/Bi2Se3_15d_5m.osc"
+  - "C:/Users/Kenpo/OneDrive/Research/Rigaku XRD/ORNL_4_12_24/Varying/Images/Bi2Se3_30d_2m.osc"
+geometry_poni: "C:/Users/Kenpo/OneDrive - University of Missouri/David and Paul/PbI2/Catalog/3.18.24/geometry.poni"
+cif_file: "C:/Users/Kenpo/OneDrive - University of Missouri/David and Paul/PbI2/Catalog/3.18.24/PbI2.cif"
+measured_peaks: "C:/Users/Kenpo/OneDrive/Documents/GitHub/blobs.npy"
+parameters_file: "C:/Users/Kenpo/parameters.npy"
+
+# GUI defaults
+gui_geometry_poni: "C:/Users/Kenpo/OneDrive/Research/Rigaku XRD/ORNL_4_12_24/Analysis/Bi2Se3/geometry.poni"
+gui_background_image: "C:/Users/Kenpo/OneDrive/Research/Rigaku XRD/ORNL_4_12_24/Analysis/Bi2Se3/In-Plane/3/Bi2Se3_6d_5m.asc"
+
+# Simulation debug log
+debug_log_csv: "~/Downloads/mosaic_full_debug_log.csv"
+
+# Test scripts
+test_cif_file: "C:/Users/Kenpo/OneDrive/Research/Rigaku XRD/ORNL.07.25.2024/Analysis/Bi2Se3/Bi2Se3_test.cif"
+test_poni_file: "C:/Users/Kenpo/OneDrive/Research/Rigaku XRD/ORNL.07.25.2024/Analysis/geometry.poni"
+test_blob_file: "C:/Users/Kenpo/OneDrive/Documents/GitHub/blobs.npy"
+overlay_output: "C:/Users/Kenpo/Downloads/overlay.png"
+file_dialog_dir: "C:/Users/Kenpo/Downloads"

--- a/main.py
+++ b/main.py
@@ -53,14 +53,17 @@ DEBUG_ENABLED = False
 ###############################################################################
 #                          DATA & PARAMETER SETUP
 ###############################################################################
-file_path = r"C:\Users\Kenpo\OneDrive\Research\Rigaku XRD\ORNL.07.25.2024\Varying\Images\darkImg.osc"
+from ra_sim.path_config import get_path
+
+file_path = get_path("dark_image")
 BI = read_osc(file_path)  # Dark (background) image
 
-file1 = read_osc(r"C:\Users\Kenpo\OneDrive - University of Missouri\David and Paul\PbI2\Catalog\3.18.24\B_4deg_2m.osc")
+osc_files = get_path("osc_files")
+file1 = read_osc(osc_files[0])
 #file1 = read_osc(r"C:\Users\Kenpo\OneDrive\Research\Rigaku XRD\ORNL.07.25.2024\Varying\Images\Bi2Se3_5m_5d.osc")
-file2 = read_osc(r"C:\Users\Kenpo\OneDrive\Research\Rigaku XRD\ORNL.07.25.2024\Varying\Images\Bi2Se3_10d_5m.osc")
-file3 = read_osc(r"C:\Users\Kenpo\OneDrive\Research\Rigaku XRD\ORNL.07.25.2024\Varying\Images\Bi2Se3_15d_5m.osc")
-file4 = read_osc(r"C:\Users\Kenpo\OneDrive\Research\Rigaku XRD\ORNL_4_12_24\Varying\Images\Bi2Se3_30d_2m.osc")
+file2 = read_osc(osc_files[1])
+file3 = read_osc(osc_files[2])
+file4 = read_osc(osc_files[3])
 
 #bg1 = np.load(r"C:\Users\Kenpo\Downloads\background_6d.npy")
 #bg2 = np.load(r"C:\Users\Kenpo\Downloads\background_10d.npy")
@@ -76,7 +79,7 @@ files = [file1, file2, file3, file4]
 background_images = files
 
 # Parse geometry
-poni_file_path = r"C:\Users\Kenpo\OneDrive - University of Missouri\David and Paul\PbI2\Catalog\3.18.24\geometry.poni"
+poni_file_path = get_path("geometry_poni")
 parameters = parse_poni_file(poni_file_path)
 
 Distance_CoR_to_Detector = parameters.get("Dist", 0.075)
@@ -121,7 +124,7 @@ bandwidth = 0.7 / 100  # 0.7%
 occ = [1.0, 1.0, 1.0]
 
 # Parameters and file paths.
-cif_file = r"C:\Users\Kenpo\OneDrive - University of Missouri\David and Paul\PbI2\Catalog\3.18.24\PbI2.cif"
+cif_file = get_path("cif_file")
 from collections import defaultdict
 import numpy as np, os, math, tempfile
 import Dans_Diffraction as dif  # your diffraction module
@@ -258,7 +261,7 @@ current_background_image = background_images[0]
 current_background_index = 0
 background_visible = True
 
-measured_peaks = np.load(r"C:\Users\Kenpo\OneDrive\Documents\GitHub\blobs.npy", allow_pickle=True)
+measured_peaks = np.load(get_path("measured_peaks"), allow_pickle=True)
 
 defaults = {
     'theta_initial': 5.0,
@@ -1094,7 +1097,7 @@ chi_square_label.pack(side=tk.BOTTOM, padx=5)
 save_button = ttk.Button(
     text="Save Params",
     command=lambda: save_all_parameters(
-        r"C:\Users\Kenpo\parameters.npy",
+        get_path("parameters_file"),
         theta_initial_var,
         gamma_var,
         Gamma_var,
@@ -1120,7 +1123,7 @@ load_button = ttk.Button(
     command=lambda: (
         progress_label.config(
             text=load_parameters(
-                r"C:\Users\Kenpo\parameters.npy",
+                get_path("parameters_file"),
                 theta_initial_var,
                 gamma_var,
                 Gamma_var,
@@ -1426,7 +1429,7 @@ def save_1d_snapshot():
     Save only the final 2D simulated image as a .npy file.
     """
     file_path = filedialog.asksaveasfilename(
-        initialdir=r"C:\Users\Kenpo\Downloads",
+        initialdir=get_path("file_dialog_dir"),
         defaultextension=".npy",
         filetypes=[("NumPy files", "*.npy"), ("All files", "*.*")]
     )
@@ -1813,7 +1816,7 @@ force_update_button.grid(row=3, column=0, columnspan=2, pady=5)
 def main():
     """Entry point for running the GUI application."""
 
-    params_file_path = r"C:\Users\Kenpo\parameters.npy"
+    params_file_path = get_path("parameters_file")
     if os.path.exists(params_file_path):
         load_parameters(
             params_file_path,

--- a/ra_sim/gui/main_app.py
+++ b/ra_sim/gui/main_app.py
@@ -15,18 +15,19 @@ from ra_sim.simulation.geometry import setup_azimuthal_integrator
 from ra_sim.simulation.diffraction import simulate_diffraction_pattern
 from ra_sim.simulation.mosaic_profiles import sample_pseudo_voigt_2d
 from ra_sim.utils.constants import av, cv, q_c
+from ra_sim.path_config import get_path
 
 def main():
     root = tk.Tk()
     root.title("XRD Analysis")
 
     # Load parameters
-    poni_path = r"C:\Users\Kenpo\OneDrive\Research\Rigaku XRD\ORNL_4_12_24\Analysis\Bi2Se3\geometry.poni"
+    poni_path = get_path("gui_geometry_poni")
     params = parse_poni_file(poni_path)
     ai = setup_azimuthal_integrator(params)
 
     # Load a background image
-    bg_image_path = r"C:\Users\Kenpo\OneDrive\Research\Rigaku XRD\ORNL_4_12_24\Analysis\Bi2Se3\In-Plane\3\Bi2Se3_6d_5m.asc"
+    bg_image_path = get_path("gui_background_image")
     bg_image = load_background_image(bg_image_path)
 
     # Setup figure

--- a/ra_sim/path_config.py
+++ b/ra_sim/path_config.py
@@ -1,0 +1,19 @@
+"""Utility for accessing common file paths."""
+from pathlib import Path
+import os
+import yaml
+
+_YAML_PATH = Path(__file__).resolve().parents[1] / "file_paths.yaml"
+
+with open(_YAML_PATH, "r", encoding="utf-8") as fh:
+    PATHS = yaml.safe_load(fh)
+
+
+def get_path(key: str) -> str:
+    """Return the configured path for *key* expanding '~'."""
+    value = PATHS.get(key)
+    if value is None:
+        raise KeyError(f"No path configured for {key!r}")
+    if isinstance(value, str):
+        return os.path.expanduser(value)
+    return value

--- a/ra_sim/simulation/diffraction_debug.py
+++ b/ra_sim/simulation/diffraction_debug.py
@@ -1,6 +1,7 @@
 import os
 import csv
 import datetime
+from ra_sim.path_config import get_path
 import numpy as np
 from math import sin, cos, sqrt, pi, exp, acos
 
@@ -14,7 +15,7 @@ def dump_debug_log():
     Writes the global debug log to ~/Downloads/mosaic_full_debug_log.csv,
     ensuring columns like 'IntersectionDetector', 'EventType', 'Qx', 'Qy', etc. exist.
     """
-    filename = os.path.expanduser("~/Downloads/mosaic_full_debug_log.csv")
+    filename = get_path("debug_log_csv")
     now_str = datetime.datetime.now().isoformat()
 
     fieldnames = [

--- a/tests/optimization.py
+++ b/tests/optimization.py
@@ -28,6 +28,7 @@ from ra_sim.utils.tools                import miller_generator
 from ra_sim.simulation.mosaic_profiles import generate_random_profiles
 from ra_sim.simulation.diffraction     import process_peaks_parallel
 from ra_sim.io.file_parsing            import parse_poni_file
+from ra_sim.path_config                import get_path
 
 # ════════════════════════════════════════════════════════════════
 # 1. Parsing helpers
@@ -250,11 +251,11 @@ def plot_shared_overlay(
 # ════════════════════════════════════════════════════════════════
 def main():
     # ── file paths ───────────────────────────────────────────────
-    cif_file  = Path(r"C:/Users/Kenpo/OneDrive/Research/Rigaku XRD/ORNL.07.25.2024/Analysis/Bi2Se3/Bi2Se3_test.cif")
-    poni_file = Path(r"C:/Users/Kenpo/OneDrive/Research/Rigaku XRD/ORNL.07.25.2024/Analysis/geometry.poni")
-    blob_file = Path(r"C:/Users/Kenpo/OneDrive/Documents/GitHub/blobs.npy")
+    cif_file  = Path(get_path("test_cif_file"))
+    poni_file = Path(get_path("test_poni_file"))
+    blob_file = Path(get_path("test_blob_file"))
     DET_SIZE = 3000
-    FIG_OUT  = Path(r"C:\Users\Kenpo\Downloads\overlay.png")
+    FIG_OUT  = Path(get_path("overlay_output"))
     geometry = parse_geometry(poni_file)
     blob_df  = load_blobs(blob_file)
     blob_df[["|H|","|K|","|L|"]]=blob_df[["H","K","L"]].abs()

--- a/tests/run_diffraction_test.py
+++ b/tests/run_diffraction_test.py
@@ -20,6 +20,7 @@ from ra_sim.utils.tools          import miller_generator
 from ra_sim.simulation.mosaic_profiles import generate_random_profiles
 from ra_sim.simulation.diffraction     import process_peaks_parallel
 from ra_sim.io.file_parsing      import parse_poni_file
+from ra_sim.path_config          import get_path
 import io, contextlib
 from CifFile import ReadCif
 
@@ -31,8 +32,8 @@ def silent_ReadCif(path):
     return cf
 
 # ───────────── file locations ─────────────
-CIF_FILE  = r"C:\Users\Kenpo\OneDrive\Research\Rigaku XRD\ORNL.07.25.2024\Analysis\Bi2Se3\Bi2Se3_test.cif"
-PONI_FILE = r"C:\Users\Kenpo\OneDrive\Research\Rigaku XRD\ORNL.07.25.2024\Analysis\geometry.poni"
+CIF_FILE  = get_path("test_cif_file")
+PONI_FILE = get_path("test_poni_file")
 
 # ───────────── geometry & wavelength ─────────────
 poni  = parse_poni_file(PONI_FILE)


### PR DESCRIPTION
## Summary
- collect paths into `file_paths.yaml`
- load paths via new `path_config` module
- refactor modules and test scripts to use configured paths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6841d0f2be7883339dbf7234a253ad54