### PR TITLE
Use CIF cell parameters and config for IoR constants

### DIFF
--- a/ior_params.yaml
+++ b/ior_params.yaml
@@ -1,0 +1,13 @@
+classical_electron_radius: 2.8179403267e-15
+default_wavelength: 1.54e-10
+avogadro_number: 6.022e23
+atomic_masses:
+  Bi: 208.98
+  Se: 78.96
+mass_attenuation_coefficients:
+  Bi: 237.8
+  Se: 81.16
+compound_density: 6.82
+atomic_numbers:
+  Bi: 83
+  Se: 34

--- a/ra_sim/StructureFactor/AtomicCoordinates.py
+++ b/ra_sim/StructureFactor/AtomicCoordinates.py
@@ -3,7 +3,7 @@
 import numpy as np
 import spglib
 
-def get_Atomic_Coordinates( positions, space_group_operations, atomic_labels):
+def get_Atomic_Coordinates(positions, space_group_operations, atomic_labels, cell_params):
     # Apply space group symmetry operations to generate all atomic fractional coordinates
     all_positions = []
     all_labels = []
@@ -14,9 +14,8 @@ def get_Atomic_Coordinates( positions, space_group_operations, atomic_labels):
             all_positions.append(new_pos)
             all_labels.append(label)
 
-    # Define cell parameters directly
-    a, b, c = 4.143000, 4.143000, 28.636000
-    alpha, beta, gamma = 90.0, 90.0, 120.0
+    # Use cell parameters provided from the CIF file
+    a, b, c, alpha, beta, gamma = cell_params
 
     # Instead of returning (label, [x, y, z]), return (label, x, y, z) directly
     atoms = [(label, pos[0], pos[1], pos[2]) for label, pos in zip(all_labels, all_positions)]
@@ -42,8 +41,8 @@ def get_Atomic_Coordinates( positions, space_group_operations, atomic_labels):
 
     return (a, b, c, alpha, beta, gamma), atoms
 
-def write_xtl(lattice, positions, numbers, space_group_operations, atomic_labels, filename="output.xtl"):
-    (a, b, c, alpha, beta, gamma), atoms = get_Atomic_Coordinates(lattice, positions, numbers, space_group_operations, atomic_labels)
+def write_xtl(lattice, positions, numbers, space_group_operations, atomic_labels, cell_params, filename="output.xtl"):
+    (a, b, c, alpha, beta, gamma), atoms = get_Atomic_Coordinates(lattice, positions, numbers, space_group_operations, atomic_labels, cell_params)
     
     # Define the dtype for the structured array
     atom_dtype = np.dtype([


### PR DESCRIPTION
## Summary
- load Bi2Se3 index-of-refraction constants from new `ior_params.yaml`
- update `IndexofRefraction` to use YAML parameters
- remove hard-coded lattice parameters in `AtomicCoordinates`
- allow `write_xtl` to receive CIF-derived cell parameters

## Testing
- `pytest -q` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6841d69de5d083338a75b35befd47f42