### PR TITLE
Add cache directory defaults

### DIFF
--- a/dir_paths.yaml
+++ b/dir_paths.yaml
@@ -1,0 +1,5 @@
+downloads: "~/Downloads"
+overlay_dir: "~/.cache/ra_sim/overlays"
+debug_log_dir: "~/.cache/ra_sim/logs"
+file_dialog_dir: "~/.local/share/ra_sim"
+temp_root: "~/.cache/ra_sim"

--- a/file_paths.yaml
+++ b/file_paths.yaml
@@ -17,7 +17,7 @@ gui_geometry_poni: "C:/Users/Kenpo/OneDrive/Research/Rigaku XRD/ORNL_4_12_24/Ana
 gui_background_image: "C:/Users/Kenpo/OneDrive/Research/Rigaku XRD/ORNL_4_12_24/Analysis/Bi2Se3/In-Plane/3/Bi2Se3_6d_5m.asc"
 
 # Simulation debug log
-debug_log_csv: "~/Downloads/mosaic_full_debug_log.csv"
+debug_log_csv: "~/.cache/ra_sim/logs/mosaic_full_debug_log.csv"
 
 # Test scripts
 test_cif_file: "C:/Users/Kenpo/OneDrive/Research/Rigaku XRD/ORNL.07.25.2024/Analysis/Bi2Se3/Bi2Se3_test.cif"

--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ DEBUG_ENABLED = False
 ###############################################################################
 #                          DATA & PARAMETER SETUP
 ###############################################################################
-from ra_sim.path_config import get_path
+from ra_sim.path_config import get_path, get_dir
 
 file_path = get_path("dark_image")
 BI = read_osc(file_path)  # Dark (background) image
@@ -198,9 +198,9 @@ for i, group_details in enumerate(details):
 
 df_details = pd.DataFrame(details_list)
 
-# Save the initial intensities to Excel in the user's Downloads folder.
-download_dir = os.path.join(os.path.expanduser("~"), "Downloads")
-excel_path = os.path.join(download_dir, "miller_intensities.xlsx")
+# Save the initial intensities to Excel in the configured downloads directory.
+download_dir = get_dir("downloads")
+excel_path = download_dir / "miller_intensities.xlsx"
 
 with pd.ExcelWriter(excel_path, engine='xlsxwriter') as writer:
     df_summary.to_excel(writer, sheet_name='Summary', index=False)
@@ -1292,10 +1292,9 @@ def on_fit_geometry_click():
         })
 
     # ─────────────────────────────────────────────────────────────────────
-    # ❸  SAVE AUTOMATICALLY INTO  ~/Downloads/
+    # ❸  SAVE AUTOMATICALLY INTO configured downloads directory
 
-    download_dir = Path.home() / "Downloads"
-    download_dir.mkdir(exist_ok=True)          # just in case
+    download_dir = get_dir("downloads")
 
     stamp      = datetime.now().strftime("%Y%m%d_%H%M%S")
     save_path  = download_dir / f"matched_peaks_{stamp}.npy"
@@ -1428,7 +1427,7 @@ def save_1d_snapshot():
     Save only the final 2D simulated image as a .npy file.
     """
     file_path = filedialog.asksaveasfilename(
-        initialdir=get_path("file_dialog_dir"),
+        initialdir=get_dir("file_dialog_dir"),
         defaultextension=".npy",
         filetypes=[("NumPy files", "*.npy"), ("All files", "*.*")]
     )

--- a/ra_sim/path_config.py
+++ b/ra_sim/path_config.py
@@ -1,12 +1,30 @@
-"""Utility for accessing common file paths."""
+"""Utility for accessing common file and directory paths."""
 from pathlib import Path
 import os
+import tempfile
 import yaml
 
 _YAML_PATH = Path(__file__).resolve().parents[1] / "file_paths.yaml"
+_DIR_YAML_PATH = Path(__file__).resolve().parents[1] / "dir_paths.yaml"
+
+DEFAULT_DIRS = {
+    "downloads": str(Path.home() / "Downloads"),
+    "overlay_dir": str(Path.home() / ".cache" / "ra_sim" / "overlays"),
+    "debug_log_dir": str(Path.home() / ".cache" / "ra_sim" / "logs"),
+    "file_dialog_dir": str(Path.home() / ".local" / "share" / "ra_sim"),
+    "temp_root": str(Path.home() / ".cache" / "ra_sim"),
+}
 
 with open(_YAML_PATH, "r", encoding="utf-8") as fh:
     PATHS = yaml.safe_load(fh)
+
+if _DIR_YAML_PATH.exists():
+    with open(_DIR_YAML_PATH, "r", encoding="utf-8") as fh:
+        yaml_dirs = yaml.safe_load(fh)
+else:
+    yaml_dirs = {}
+
+DIRS = {**DEFAULT_DIRS, **yaml_dirs}
 
 
 def get_path(key: str) -> str:
@@ -17,3 +35,30 @@ def get_path(key: str) -> str:
     if isinstance(value, str):
         return os.path.expanduser(value)
     return value
+
+
+def get_dir(key: str) -> Path:
+    """Return the configured directory for *key*, creating it if needed."""
+    value = DIRS.get(key)
+    if value is None:
+        raise KeyError(f"No directory configured for {key!r}")
+    path = Path(os.path.expanduser(value))
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+_TEMP_DIR = None
+
+
+def get_temp_dir() -> Path:
+    """Return a dedicated temporary directory for the current session."""
+    global _TEMP_DIR
+    if _TEMP_DIR is None:
+        base = DIRS.get("temp_root")
+        if base:
+            base_path = Path(os.path.expanduser(base))
+        else:
+            base_path = Path(tempfile.gettempdir()) / "ra_sim"
+        base_path.mkdir(parents=True, exist_ok=True)
+        _TEMP_DIR = Path(tempfile.mkdtemp(prefix="ra_sim_", dir=str(base_path)))
+    return _TEMP_DIR

--- a/ra_sim/simulation/diffraction_debug.py
+++ b/ra_sim/simulation/diffraction_debug.py
@@ -1,7 +1,8 @@
 import os
 import csv
 import datetime
-from ra_sim.path_config import get_path
+from pathlib import Path
+from ra_sim.path_config import get_dir
 import numpy as np
 from math import sin, cos, sqrt, pi, exp, acos
 
@@ -11,11 +12,9 @@ from math import sin, cos, sqrt, pi, exp, acos
 DEBUG_LOG = []
 
 def dump_debug_log():
-    """
-    Writes the global debug log to ~/Downloads/mosaic_full_debug_log.csv,
-    ensuring columns like 'IntersectionDetector', 'EventType', 'Qx', 'Qy', etc. exist.
-    """
-    filename = get_path("debug_log_csv")
+    """Write the global debug log to ``debug_log_dir`` as ``mosaic_full_debug_log.csv``."""
+    log_dir = get_dir("debug_log_dir")
+    filename = Path(log_dir) / "mosaic_full_debug_log.csv"
     now_str = datetime.datetime.now().isoformat()
 
     fieldnames = [

--- a/ra_sim/utils/tools.py
+++ b/ra_sim/utils/tools.py
@@ -13,6 +13,7 @@ from skimage import color, exposure, feature, io
 
 from ra_sim.StructureFactor.StructureFactor import calculate_structure_factor
 from ra_sim.utils.calculations import d_spacing, two_theta
+from ra_sim.path_config import get_temp_dir
 
 def detect_blobs(
     source,
@@ -322,8 +323,10 @@ def miller_generator(mx, cif_file, occ, lambda_, energy=8.047,
             occupancies[i] = str(original * factor)
     # ---------------------------------------------------------------------
 
-    # Write the updated CIF to a temporary file.
-    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".cif", delete=False)
+    # Write the updated CIF to a temporary file within our temp directory.
+    tmp_dir = get_temp_dir()
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".cif", delete=False,
+                                      dir=str(tmp_dir))
     tmp.close()  # Close the file to allow writing via PyCifRW.
     # If your version of PyCifRW provides a WriteCif function, you can use it.
     # Otherwise, use the WriteOut method on the CIF object.

--- a/tests/optimization.py
+++ b/tests/optimization.py
@@ -28,7 +28,7 @@ from ra_sim.utils.tools                import miller_generator
 from ra_sim.simulation.mosaic_profiles import generate_random_profiles
 from ra_sim.simulation.diffraction     import process_peaks_parallel
 from ra_sim.io.file_parsing            import parse_poni_file
-from ra_sim.path_config                import get_path
+from ra_sim.path_config                import get_path, get_dir
 
 # ════════════════════════════════════════════════════════════════
 # 1. Parsing helpers
@@ -255,7 +255,8 @@ def main():
     poni_file = Path(get_path("test_poni_file"))
     blob_file = Path(get_path("test_blob_file"))
     DET_SIZE = 3000
-    FIG_OUT  = Path(get_path("overlay_output"))
+    overlay_dir = get_dir("overlay_dir")
+    FIG_OUT = overlay_dir / "overlay.png"
     geometry = parse_geometry(poni_file)
     blob_df  = load_blobs(blob_file)
     blob_df[["|H|","|K|","|L|"]]=blob_df[["H","K","L"]].abs()


### PR DESCRIPTION
## Summary
- default overlay and log outputs to hidden cache directories
- give fallback defaults in `path_config`
- move debug log to `debug_log_dir`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6841f6b5204c8333a48bb2d6094457d1