### PR TITLE
Add debug status output from diffraction solver

### DIFF
--- a/file_paths.yaml
+++ b/file_paths.yaml
@@ -20,8 +20,8 @@ gui_background_image: "C:/Users/Kenpo/OneDrive/Research/Rigaku XRD/ORNL_4_12_24/
 debug_log_csv: "~/.cache/ra_sim/logs/mosaic_full_debug_log.csv"
 
 # Test scripts
-test_cif_file: "C:/Users/Kenpo/OneDrive/Research/Rigaku XRD/ORNL.07.25.2024/Analysis/Bi2Se3/Bi2Se3_test.cif"
-test_poni_file: "C:/Users/Kenpo/OneDrive/Research/Rigaku XRD/ORNL.07.25.2024/Analysis/geometry.poni"
+test_cif_file: tests/local_test.cif
+test_poni_file: tests/local_geometry.poni
 test_blob_file: "C:/Users/Kenpo/OneDrive/Documents/GitHub/blobs.npy"
 overlay_output: "C:/Users/Kenpo/Downloads/overlay.png"
 file_dialog_dir: "C:/Users/Kenpo/Downloads"

--- a/tests/analyze_simulation_debug.py
+++ b/tests/analyze_simulation_debug.py
@@ -22,6 +22,7 @@ with np.load(NPZ_PATH, allow_pickle=True) as data:
         dbg = data["debug_info"]
     except KeyError:
         raise SystemExit("debug_info entry not found in npz file")
+    solve_status = data["solve_status"] if "solve_status" in data else None
 
 theta = np.rad2deg(dbg[:, 0])
 phi = np.rad2deg(dbg[:, 1])
@@ -37,6 +38,12 @@ print(f"hit sample:    {n_hit_sample} ({n_hit_sample/n_total:.1%})")
 print(f"hit detector:  {n_hit_det} ({n_hit_det/n_total:.1%})")
 print(f"missed sample: {n_total - n_hit_sample}")
 print(f"missed detector after sample hit: {n_hit_sample - n_hit_det}")
+
+if solve_status is not None:
+    unique, counts = np.unique(solve_status, return_counts=True)
+    print("solve_q status codes:")
+    for u, c in zip(unique, counts):
+        print(f"  {int(u)}: {c}")
 
 # classify for scatter plot
 cls = np.full(n_total, 0)

--- a/tests/local_geometry.poni
+++ b/tests/local_geometry.poni
@@ -1,0 +1,6 @@
+Dist: 0.075
+Rot1: 0.0
+Rot2: 0.0
+Poni1: 0.0
+Poni2: 0.0
+Wavelength: 1e-10

--- a/tests/local_test.cif
+++ b/tests/local_test.cif
@@ -1,0 +1,4 @@
+#
+data_test
+_cell_length_a    4.0
+_cell_length_c    10.0

--- a/tests/run_diffraction_test.py
+++ b/tests/run_diffraction_test.py
@@ -115,7 +115,7 @@ mosaic_params = dict(
 sim_buffer = np.zeros((IMAGE_SIZE, IMAGE_SIZE), np.float64)
 
 # grab *all* outputs
-image, hit_tables, q_data, q_count = process_peaks_parallel(
+image, hit_tables, q_data, q_count, solve_status = process_peaks_parallel(
     miller, intens, IMAGE_SIZE,
     a_v, c_v, λ,
     sim_buffer,
@@ -135,7 +135,8 @@ image, hit_tables, q_data, q_count = process_peaks_parallel(
     theta_initial,
     np.array([1.0,0.0,0.0]),
     np.array([0.0,1.0,0.0]),
-    save_flag=0
+    save_flag=0,
+    record_status=True
 
 )
 
@@ -199,6 +200,7 @@ if q_data is not None:
     arrays["q_count"] = _detach(q_count)
 
 arrays["debug_info"] = _detach(debug_info)
+arrays["solve_status"] = _detach(solve_status)
 
 # finally write the .npz
 np.savez(script_dir / "simulation.npz", **arrays)


### PR DESCRIPTION
## Summary
- track failure status in `solve_q`
- propagate debug info through `calculate_phi` and `process_peaks_parallel`
- log solve status in `run_diffraction_test.py` and `analyze_simulation_debug.py`
- include local test `.poni` and `.cif` files
- update path config for tests

## Testing
- `python tests/run_diffraction_test.py` *(fails: Occupancy tag '_atom_site_occupancy' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432d67f55083339cae3feac0445305