### PR TITLE
Fix numba return types

### DIFF
--- a/ra_sim/utils/tools.py
+++ b/ra_sim/utils/tools.py
@@ -290,7 +290,11 @@ def miller_generator(mx, cif_file, occ, lambda_, energy=8.047,
     # Get the occupancy values; expect a list.
     occupancies = block.get("_atom_site_occupancy")
     if occupancies is None:
-        raise ValueError("Occupancy tag '_atom_site_occupancy' not found in CIF block.")
+        labels = block.get("_atom_site_label")
+        if isinstance(labels, list):
+            occupancies = ["1.0"] * len(labels)
+        else:
+            occupancies = ["1.0"]
 
     # Determine whether to update each occupancy individually or uniformly.
     if isinstance(occ, (list, tuple)):


### PR DESCRIPTION
## Summary
- avoid error in utils.tools when CIF doesn't specify occupancy
- unify `solve_q` returns and adjust callers
- standardize `process_peaks_parallel` outputs

## Testing
- `pytest -q` *(fails: zero tests or long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_6843313ca18c8333879ac0eab08b4655