### PR TITLE
Improve diffraction debug output

### DIFF
--- a/main.py
+++ b/main.py
@@ -780,7 +780,7 @@ def do_update():
         sim_buffer = np.zeros((image_size, image_size), dtype=np.float64)
 
         # Re-use the globally updated miller, intensities from occupancy changes:
-        updated_image, max_positions_local, _, _, _ = process_peaks_parallel(
+        updated_image, max_positions_local, _, _, _, _ = process_peaks_parallel(
             miller, intensities, image_size,
             a_updated, c_updated, lambda_,
             sim_buffer, corto_det_up,
@@ -1497,7 +1497,7 @@ def save_q_space_representation():
         "eta": profile_cache.get("eta", 0.0)
     }
 
-    image_result, max_positions_local, q_data, q_count, _ = process_peaks_parallel(
+    image_result, max_positions_local, q_data, q_count, _, _ = process_peaks_parallel(
         miller,
         intensities,
         image_size,

--- a/ra_sim/fitting/optimization.py
+++ b/ra_sim/fitting/optimization.py
@@ -51,7 +51,7 @@ def simulate_and_compare_hkl(
         wavelength_array = mosaic.get('wavelength_i_array')
 
     # Full-pattern simulation
-    updated_image, maxpos, _, _ = process_peaks_parallel(
+    updated_image, maxpos, _, _, _ = process_peaks_parallel(
         miller, intensities, image_size,
         a, c, wavelength_array,
         sim_buffer, dist,

--- a/ra_sim/simulation/simulation.py
+++ b/ra_sim/simulation/simulation.py
@@ -30,7 +30,7 @@ def simulate_diffraction(theta_initial, gamma, Gamma, chi, zs, zb, debye_x_value
     unit_x = np.array([1.0, 0.0, 0.0])
     n_detector = np.array([0.0, 1.0, 0.0])
     
-    simulated_image = process_peaks_parallel(
+    simulated_image, *_ = process_peaks_parallel(
         miller, intensities, image_size, av, cv, lambda_, np.zeros((image_size, image_size)),
         corto_detector_value, gamma, Gamma, chi, psi, zs, zb, n2,
         beam_x_array, beam_y_array, beam_intensity_array,

--- a/tests/analyze_simulation_debug.py
+++ b/tests/analyze_simulation_debug.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python3
-"""Analyze beam paths from ``simulation.npz``.
+"""Analyze missed diffracted rays from ``simulation.npz``.
 
-This script inspects the ``debug_info`` array stored by
-``tests/run_diffraction_test.py``.  Each row in ``debug_info`` contains
-``(theta, phi, hit_sample, hit_detector)`` for one beam sample.
-The goal is to understand which samples miss the detector to diagnose the
-horizontal black band issue.
-"""
+``tests/run_diffraction_test.py`` stores outgoing wavevectors that failed
+to intersect the detector plane in ``debug_info``.  This script simply
+reports how many such vectors were recorded and plots their directions."""
 import numpy as np
 import matplotlib.pyplot as plt
 from pathlib import Path
@@ -24,20 +21,10 @@ with np.load(NPZ_PATH, allow_pickle=True) as data:
         raise SystemExit("debug_info entry not found in npz file")
     solve_status = data["solve_status"] if "solve_status" in data else None
 
-theta = np.rad2deg(dbg[:, 0])
-phi = np.rad2deg(dbg[:, 1])
-hit_sample = dbg[:, 2] > 0.5
-hit_detector = dbg[:, 3] > 0.5
+theta = np.rad2deg(np.arctan2(dbg[:, 2], np.sqrt(dbg[:, 0]**2 + dbg[:, 1]**2)))
+phi = np.rad2deg(np.arctan2(dbg[:, 0], dbg[:, 1]))
 
-n_total = dbg.shape[0]
-n_hit_sample = np.count_nonzero(hit_sample)
-n_hit_det = np.count_nonzero(hit_detector)
-
-print(f"total samples: {n_total}")
-print(f"hit sample:    {n_hit_sample} ({n_hit_sample/n_total:.1%})")
-print(f"hit detector:  {n_hit_det} ({n_hit_det/n_total:.1%})")
-print(f"missed sample: {n_total - n_hit_sample}")
-print(f"missed detector after sample hit: {n_hit_sample - n_hit_det}")
+print(f"total missed rays: {dbg.shape[0]}")
 
 if solve_status is not None:
     unique, counts = np.unique(solve_status, return_counts=True)
@@ -45,21 +32,10 @@ if solve_status is not None:
     for u, c in zip(unique, counts):
         print(f"  {int(u)}: {c}")
 
-# classify for scatter plot
-cls = np.full(n_total, 0)
-cls[hit_sample] = 1
-cls[hit_detector] = 2
-colors = np.array(["red", "orange", "green"])[cls]
-labels = {0: "missed sample", 1: "missed detector", 2: "hit detector"}
-
 plt.figure(figsize=(6, 5))
-for c in np.unique(cls):
-    mask = cls == c
-    plt.scatter(phi[mask], theta[mask], s=10, c=colors[mask], label=labels[c])
-
+plt.scatter(phi, theta, s=10, color="red")
 plt.xlabel("phi (deg)")
 plt.ylabel("theta (deg)")
-plt.title("Beam path classification")
-plt.legend()
+plt.title("Missed ray directions")
 plt.tight_layout()
 plt.show()

--- a/tests/run_diffraction_test.py
+++ b/tests/run_diffraction_test.py
@@ -18,7 +18,7 @@ import CifFile
 from ra_sim.utils.calculations   import IndexofRefraction
 from ra_sim.utils.tools          import miller_generator
 from ra_sim.simulation.mosaic_profiles import generate_random_profiles
-from ra_sim.simulation.diffraction     import process_peaks_parallel, debug_detector_paths
+from ra_sim.simulation.diffraction     import process_peaks_parallel
 from ra_sim.io.file_parsing      import parse_poni_file
 from ra_sim.path_config          import get_path
 import io, contextlib
@@ -115,7 +115,7 @@ mosaic_params = dict(
 sim_buffer = np.zeros((IMAGE_SIZE, IMAGE_SIZE), np.float64)
 
 # grab *all* outputs
-image, hit_tables, q_data, q_count, solve_status = process_peaks_parallel(
+image, hit_tables, q_data, q_count, solve_status, miss_tables = process_peaks_parallel(
     miller, intens, IMAGE_SIZE,
     a_v, c_v, λ,
     sim_buffer,
@@ -141,17 +141,7 @@ image, hit_tables, q_data, q_count, solve_status = process_peaks_parallel(
 )
 
 # ───────────── additional geometry debug info ─────────────
-debug_info = debug_detector_paths(
-    mosaic_params["beam_x_array"],
-    mosaic_params["beam_y_array"],
-    mosaic_params["theta_array"],
-    mosaic_params["phi_array"],
-    theta_initial, chi, psi,
-    zb, zs,
-    dist, rot1, rot2,
-    np.array([0.0,1.0,0.0]),
-    np.array([1.0,0.0,0.0])
-)
+debug_info = miss_tables[0]
 
 
 # ───────────── Display ─────────────


### PR DESCRIPTION
## Summary
- expose outgoing wavevectors that miss the detector
- propagate missed rays through `process_peaks_parallel`
- adapt command line scripts to use the new info
- update analysis script for new format

## Testing
- `python tests/run_diffraction_test.py` *(fails without dependencies; after installing they run successfully)*
- `python tests/analyze_simulation_debug.py`

------
https://chatgpt.com/codex/tasks/task_e_6843431465d08333b73b8f181507d28e