### PR TITLE
Fix analysis of debug vectors

### DIFF
--- a/tests/analyze_simulation_debug.py
+++ b/tests/analyze_simulation_debug.py
@@ -2,8 +2,11 @@
 """Analyze missed diffracted rays from ``simulation.npz``.
 
 ``tests/run_diffraction_test.py`` stores outgoing wavevectors that failed
-to intersect the detector plane in ``debug_info``.  This script simply
-reports how many such vectors were recorded and plots their directions."""
+to intersect the detector plane in ``debug_info``.  Earlier versions only
+recorded vectors from a single reflection.  Newer runs may store *all*
+missed vectors as an object array of per-reflection tables.  This script
+collects all vectors, reports how many were recorded and plots their
+directions."""
 import numpy as np
 import matplotlib.pyplot as plt
 from pathlib import Path
@@ -21,10 +24,17 @@ with np.load(NPZ_PATH, allow_pickle=True) as data:
         raise SystemExit("debug_info entry not found in npz file")
     solve_status = data["solve_status"] if "solve_status" in data else None
 
-theta = np.rad2deg(np.arctan2(dbg[:, 2], np.sqrt(dbg[:, 0]**2 + dbg[:, 1]**2)))
-phi = np.rad2deg(np.arctan2(dbg[:, 0], dbg[:, 1]))
+    # ``dbg`` may be a simple ``(N,3)`` array or an object array of
+    # per-reflection tables.  Normalize to a single ``(M,3)`` array.
+    if dbg.dtype == object:
+        dbg_all = np.vstack([arr for arr in dbg if len(arr) > 0])
+    else:
+        dbg_all = dbg
 
-print(f"total missed rays: {dbg.shape[0]}")
+theta = np.rad2deg(np.arctan2(dbg_all[:, 2], np.sqrt(dbg_all[:, 0]**2 + dbg_all[:, 1]**2)))
+phi = np.rad2deg(np.arctan2(dbg_all[:, 0], dbg_all[:, 1]))
+
+print(f"total missed rays: {dbg_all.shape[0]}")
 
 if solve_status is not None:
     unique, counts = np.unique(solve_status, return_counts=True)


### PR DESCRIPTION
## Summary
- allow analyze_simulation_debug to gather all missed kf vectors
- explain new behavior in docstring

## Testing
- `python -m pytest -q` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_68434a715f7083338be6300dac4b7d40