### PR TITLE
Add intensity slider to view_sim_image

### DIFF
--- a/ra_sim/simulation/diffraction.py
+++ b/ra_sim/simulation/diffraction.py
@@ -1013,9 +1013,10 @@ def process_peaks_parallel(
 
     # prange over each reflection
     for i_pk in prange(num_peaks):
-        H= miller[i_pk,0]
-        K= miller[i_pk,1]
-        L= miller[i_pk,2]
+        # Ensure HKL values remain floating point to allow fractional indices
+        H = float(miller[i_pk, 0])
+        K = float(miller[i_pk, 1])
+        L = float(miller[i_pk, 2])
         reflI= intensities[i_pk]
 
         # We'll do a reflection-level call to calculate_phi

--- a/ra_sim/simulation/diffraction_debug.py
+++ b/ra_sim/simulation/diffraction_debug.py
@@ -577,9 +577,10 @@ def process_peaks_parallel_debug(
     max_positions= np.empty((num_peaks,6), dtype=np.float64)
 
     for i_pk in range(num_peaks):
-        H= miller[i_pk,0]
-        K= miller[i_pk,1]
-        L= miller[i_pk,2]
+        # Keep HKL values as floats to avoid unintended rounding
+        H = float(miller[i_pk, 0])
+        K = float(miller[i_pk, 1])
+        L = float(miller[i_pk, 2])
         reflI= intensities[i_pk]
 
         (mx0,my0,mv0, mx1,my1,mv1) = calculate_phi(

--- a/tests/view_sim_image.py
+++ b/tests/view_sim_image.py
@@ -2,6 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import cm
 from matplotlib.colors import ListedColormap
+from matplotlib.widgets import Slider
 from pathlib import Path
 
 NPZ_PATH = Path(__file__).resolve().parent / "simulation.npz"
@@ -21,11 +22,23 @@ rgba[0] = [1, 1, 1, 1]
 turbo_white0 = ListedColormap(rgba, name="turbo_white0")
 turbo_white0.set_bad("white")
 
-plt.figure(figsize=(8, 8))
-plt.imshow(image, cmap=turbo_white0, origin="upper")
-plt.xlabel("x-pixel")
-plt.ylabel("y-pixel")
-plt.colorbar(label="Intensity")
-plt.title("Simulated diffraction pattern")
-plt.tight_layout()
+fig, ax = plt.subplots(figsize=(8, 8))
+plt.subplots_adjust(bottom=0.15)
+im = ax.imshow(image, cmap=turbo_white0, origin="upper")
+ax.set_xlabel("x-pixel")
+ax.set_ylabel("y-pixel")
+cbar = plt.colorbar(im, ax=ax, label="Intensity")
+ax.set_title("Simulated diffraction pattern")
+
+# Slider for adjusting the maximum display intensity
+slider_ax = fig.add_axes([0.2, 0.04, 0.6, 0.03])
+vmax_init = float(np.max(image))
+vmax_slider = Slider(slider_ax, "vmax", 0.0, vmax_init, valinit=vmax_init)
+
+def on_vmax_change(val):
+    im.set_clim(vmin=0.0, vmax=val)
+    fig.canvas.draw_idle()
+
+vmax_slider.on_changed(on_vmax_change)
+
 plt.show()


### PR DESCRIPTION
## Summary
- enhance `view_sim_image` viewer with an interactive slider
- ensure `process_peaks_parallel` does not round HKL values

## Testing
- `python -m py_compile tests/view_sim_image.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850560ed3ec8333a85b2e91b3a487bc