### PR TITLE
Fix HT occupancy helper path

### DIFF
--- a/ra_sim/utils/stacking_fault.py
+++ b/ra_sim/utils/stacking_fault.py
@@ -1,4 +1,5 @@
 # ────────────────────────── global constants (unchanged) ──────────────────────────
+import numpy as np
 A_HEX   = 4.557
 P_CLAMP = 1e-6
 N_P, A_C = 3, 17.98e-10
@@ -18,7 +19,7 @@ def _temp_cif_with_occ(cif_in: str, occ):
     """
     import tempfile, os, CifFile
     cf          = CifFile.ReadCif(cif_in)
-    block_name  = next(iter(cf))
+    block_name  = list(cf.keys())[0]
     block       = cf[block_name]
 
     occ_field = block.get('_atom_site_occupancy')


### PR DESCRIPTION
## Summary
- fix missing numpy import in `stacking_fault.py`
- use `list(cf.keys())[0]` to select the CIF block so `_temp_cif_with_occ` works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685981075ff483338f43cde5f9eaeee8