### PR TITLE
Add debug_print utility for RA_SIM_DEBUG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# RA Simulation
+
+This project contains a diffraction simulation tool with a Tk based GUI.
+
+## Running
+
+After installing the required packages (``pip install -r requirements.txt`` or the
+packages listed in ``setup.py``) launch the GUI with:
+
+```bash
+python main.py
+```
+
+## Troubleshooting
+
+If the program prints ``Loaded saved profile ...`` and then exits without
+showing the GUI, the parameters passed to the Numba compiled
+``process_peaks_parallel`` routine may be malformed.  When using fractional ``L``
+values the ``miller1`` and ``intens1`` arrays should contain floating point
+numbers and be contiguous.
+
+Set the environment variable ``RA_SIM_DEBUG`` to ``1`` (or any truthy value) to
+print a summary of these arrays via ``ra_sim.debug_utils.check_ht_arrays``.  On
+Linux/macOS use ``export RA_SIM_DEBUG=1``; in Windows ``cmd`` use
+``set RA_SIM_DEBUG=1`` or in PowerShell ``$env:RA_SIM_DEBUG='1'``.  You can also
+call ``ra_sim.debug_utils.debug_print`` in your own code to emit messages only
+when debug mode is active.  For manual inspection insert the snippet below in
+``main.py`` right after ``ht_dict_to_arrays`` is called:
+
+```python
+print('miller1 dtype:', miller1.dtype, 'shape:', miller1.shape)
+print('L range:', miller1[:, 2].min(), miller1[:, 2].max())
+print('intens1 dtype:', intens1.dtype, 'min:', intens1.min(), 'max:', intens1.max())
+print('miller1 contiguous:', miller1.flags['C_CONTIGUOUS'])
+print('intens1 contiguous:', intens1.flags['C_CONTIGUOUS'])
+```
+
+Run the script from the command line to see the output.  If the arrays look
+reasonable, enable the debug simulation (``Run Debug Simulation`` button) or set
+the environment variable ``RA_SIM_DEBUG=1`` (or change ``DEBUG_ENABLED`` to
+``True`` in ``main.py``) to write detailed logs from ``diffraction_debug.py``.
+These logs show intersection calculations for each reflection and help pinpoint
+where processing stops.
+
+Finally, running the unit tests provides a quick check that the intensity helper
+is functioning correctly:
+
+```bash
+pytest
+```

--- a/main.py
+++ b/main.py
@@ -58,6 +58,7 @@ from ra_sim.simulation.diffraction_debug import (
 )
 from ra_sim.simulation.simulation import simulate_diffraction
 from ra_sim.gui.sliders import create_slider
+from ra_sim.debug_utils import debug_print, is_debug_enabled
 
 turbo = cm.get_cmap('turbo', 256)          # 256-step version of ‘turbo’
 turbo_rgba = turbo(np.linspace(0, 1, 256))
@@ -68,7 +69,12 @@ turbo_white0.set_bad('white')              # NaNs will also show white
 
 # Force TkAgg backend to ensure GUI usage
 matplotlib.use('TkAgg')
-DEBUG_ENABLED = False
+# Enable extra diagnostics when the RA_SIM_DEBUG environment variable is set.
+DEBUG_ENABLED = is_debug_enabled()
+if DEBUG_ENABLED:
+    print("Debug mode active (RA_SIM_DEBUG=1)")
+else:
+    print("Debug mode off (set RA_SIM_DEBUG=1 for extra output)")
 
 ###############################################################################
 #                          DATA & PARAMETER SETUP
@@ -205,6 +211,14 @@ ht_curves = ht_Iinf_dict(                 # ← new core
 
 # ---- convert the dict → arrays compatible with the downstream code ----
 miller1, intens1, degeneracy1, details1 = ht_dict_to_arrays(ht_curves)
+
+if DEBUG_ENABLED:
+    from ra_sim.debug_utils import check_ht_arrays
+    check_ht_arrays(miller1, intens1)
+    debug_print(
+        "miller1 shape:", miller1.shape,
+        "intens1 shape:", intens1.shape
+    )
 
 has_second_cif = bool(cif_file2)
 if has_second_cif:

--- a/ra_sim/debug_utils.py
+++ b/ra_sim/debug_utils.py
@@ -1,0 +1,43 @@
+"""Helper utilities for debugging RA_SIM execution."""
+
+import os
+import numpy as np
+
+
+def is_debug_enabled() -> bool:
+    """Return ``True`` if ``RA_SIM_DEBUG`` is set to a truthy value."""
+    val = os.environ.get("RA_SIM_DEBUG", "")
+    return bool(val) and val.lower() not in {"0", "false", "no"}
+
+
+DEBUG_ENABLED = is_debug_enabled()
+
+
+def debug_print(*args, **kwargs) -> None:
+    """Print only when ``RA_SIM_DEBUG`` is enabled."""
+    if DEBUG_ENABLED:
+        print(*args, **kwargs)
+
+
+def check_ht_arrays(miller1: np.ndarray, intens1: np.ndarray) -> None:
+    """Print diagnostics for Hendricks–Teller arrays when debugging is enabled."""
+    debug_print("miller1 dtype:", miller1.dtype, "shape:", miller1.shape)
+    if miller1.size:
+        l_min = float(miller1[:, 2].min())
+        l_max = float(miller1[:, 2].max())
+        debug_print("L range:", l_min, l_max)
+        if np.allclose(miller1[:, 2], np.round(miller1[:, 2])):
+            debug_print("L values are integer-only")
+        else:
+            frac_count = np.count_nonzero(~np.isclose(miller1[:, 2], np.round(miller1[:, 2])))
+            debug_print(f"L values contain {frac_count} fractional entries")
+    else:
+        debug_print("L range: array empty")
+    if intens1.size:
+        i_min = float(intens1.min())
+        i_max = float(intens1.max())
+    else:
+        i_min = i_max = float('nan')
+    debug_print("intens1 dtype:", intens1.dtype, "min:", i_min, "max:", i_max)
+    debug_print("miller1 contiguous:", miller1.flags['C_CONTIGUOUS'])
+    debug_print("intens1 contiguous:", intens1.flags['C_CONTIGUOUS'])


### PR DESCRIPTION
## Summary
- add `debug_print` helper with RA_SIM_DEBUG toggle
- use the helper in `check_ht_arrays` and `main.py`
- document the helper in the troubleshooting section
- support truthy env values and print when debug mode is on
- show debug state at startup for easier troubleshooting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859ad0f6fc8833399e132742f390061