### PR TITLE
docs: clarify numba compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ packages listed in ``setup.py``) launch the GUI with:
 python main.py
 ```
 
+**Python compatibility**: the simulation relies on Numba-compiled routines.
+Ensure your Numba build matches your Python interpreter.  If the program exits
+after printing the initial diagnostics, your Numba version might be
+incompatible.  Installing a recent Numba release for your Python version (or
+temporarily running Python 3.11 with an older Numba) usually resolves the
+issue.
+
 ## Troubleshooting
 
 If the program prints ``Loaded saved profile ...`` and then exits without


### PR DESCRIPTION
## Summary
- refine guidance on Python/NuMBA compatibility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685a02b9d1548333bad98f4350675304