### PR TITLE
Add two_theta_max option for HT curves

### DIFF
--- a/main.py
+++ b/main.py
@@ -208,7 +208,8 @@ ht_curves = ht_Iinf_dict(                 # ← new core
     occ=occ,                              # same occupancy-scaling rules
     p=1.0,                                # disorder probability
     L_step=0.02,
-    L_max=5.0,
+    two_theta_max=two_theta_range[1],
+    lambda_=lambda_,
 )
 
 # ---- convert the dict → arrays compatible with the downstream code ----
@@ -1887,7 +1888,8 @@ def update_occupancies(*args):
         occ=new_occ,
         p=1.0,
         L_step=0.02,
-        L_max=5.0,
+        two_theta_max=two_theta_range[1],
+        lambda_=lambda_,
     )
 
     m1, i1, d1, det1 = ht_dict_to_arrays(ht_curves_local)


### PR DESCRIPTION
## Summary
- add `two_theta_max` and wavelength args to `ht_Iinf_dict`
- convert 2θ limit to per-rod L ranges
- update main program to use the new parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a23afcc208333aa0a943beb961764