### PR TITLE
Add CLI flag for Excel output

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ packages listed in ``setup.py``) launch the GUI with:
 python main.py
 ```
 
+By default an Excel file named ``miller_intensities.xlsx`` is written to the
+configured downloads directory.  Pass ``--no-excel`` to disable this step.
+
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- allow disabling Excel export from `main.py`
- wrap `to_excel` block with a flag
- document `--no-excel` option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685acf1e999c83339779b1ff87764f2c