### PR TITLE
Enable RA_SIM_DEBUG in main

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ print a summary of these arrays via ``ra_sim.debug_utils.check_ht_arrays``.  On
 Linux/macOS use ``export RA_SIM_DEBUG=1``; in Windows ``cmd`` use
 ``set RA_SIM_DEBUG=1`` or in PowerShell ``$env:RA_SIM_DEBUG='1'``.  You can also
 call ``ra_sim.debug_utils.debug_print`` in your own code to emit messages only
-when debug mode is active.  For manual inspection insert the snippet below in
+when debug mode is active. The ``main.py`` script sets ``RA_SIM_DEBUG=1`` on
+startup so logging is enabled by default. When debug mode is active, the
+``numba`` logger is configured to emit debug-level messages which can help
+troubleshoot JIT compilation errors.
+For manual inspection insert the snippet below in
 
 ``main.py`` right after ``ht_dict_to_arrays`` is called:
 

--- a/main.py
+++ b/main.py
@@ -4,6 +4,9 @@
 
 import math
 import os
+
+# Enable debug messages automatically. Set RA_SIM_DEBUG=0 to disable.
+os.environ.setdefault("RA_SIM_DEBUG", "1")
 import re
 import argparse
 import tempfile
@@ -75,6 +78,8 @@ matplotlib.use('TkAgg')
 DEBUG_ENABLED = is_debug_enabled()
 if DEBUG_ENABLED:
     print("Debug mode active (RA_SIM_DEBUG=1)")
+    from ra_sim.debug_utils import enable_numba_logging
+    enable_numba_logging()
 else:
     print("Debug mode off (set RA_SIM_DEBUG=1 for extra output)")
 


### PR DESCRIPTION
## Summary
- set `RA_SIM_DEBUG=1` from `main.py` so debug logging is enabled automatically
- explain automatic debug mode activation in the README

## Testing
- `pip install numpy`
- `pip install pillow`
- `pip install matplotlib`
- `pip install pandas`
- `pip install pyFAI`
- `pip install scikit-image`
- `pip install numba`
- `pip install pyyaml`
- `pip install Dans_Diffraction`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae778e8ac8333ba99c548b8ffdfb5