### PR TITLE
Fix slider widget crash

### DIFF
--- a/ra_sim/gui/main_app.py
+++ b/ra_sim/gui/main_app.py
@@ -44,31 +44,31 @@ def main():
 
     # Initialize variables for sliders
     theta_initial_var, _ = create_slider(
-        "Theta Initial", 5.0, 20.0, 6.0, 0.01, slider_frame
+        "Theta Initial", 5.0, 20.0, 6.0, 0.01, parent=slider_frame
     )
     gamma_var, _ = create_slider(
-        "Gamma", -5, 5, ai.rot2, 0.001, slider_frame
+        "Gamma", -5, 5, ai.rot2, 0.001, parent=slider_frame
     )
     Gamma_var, _ = create_slider(
-        "Detector Rotation Gamma", -5, 5, ai.rot1, 0.001, slider_frame
+        "Detector Rotation Gamma", -5, 5, ai.rot1, 0.001, parent=slider_frame
     )
     chi_var, _ = create_slider(
-        "Chi", -1, 1, 0.0, 0.001, slider_frame
+        "Chi", -1, 1, 0.0, 0.001, parent=slider_frame
     )
     zs_var, _ = create_slider(
-        "Zs", 0.0, 5e-3, 0.0, 0.0001, slider_frame
+        "Zs", 0.0, 5e-3, 0.0, 0.0001, parent=slider_frame
     )
     zb_var, _ = create_slider(
-        "Zb", 0.0, 5e-3, -0.1e-3, 0.0001, slider_frame
+        "Zb", 0.0, 5e-3, -0.1e-3, 0.0001, parent=slider_frame
     )
     eta_var, _ = create_slider(
-        "Eta (fraction)", 0.0, 1.0, 0.08, 0.001, slider_frame
+        "Eta (fraction)", 0.0, 1.0, 0.08, 0.001, parent=slider_frame
     )
     sigma_mosaic_var, _ = create_slider(
-        "Sigma Mosaic (deg)", 0.0, 5.0, 3.0, 0.01, slider_frame
+        "Sigma Mosaic (deg)", 0.0, 5.0, 3.0, 0.01, parent=slider_frame
     )
     gamma_mosaic_var, _ = create_slider(
-        "Gamma Mosaic (deg)", 0.0, 5.0, 0.7, 0.01, slider_frame
+        "Gamma Mosaic (deg)", 0.0, 5.0, 0.7, 0.01, parent=slider_frame
     )
 
     # Generate random profiles


### PR DESCRIPTION
## Summary
- ensure `create_slider` gets `parent` widget by keyword argument

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'Dans_Diffraction')*

------
https://chatgpt.com/codex/tasks/task_e_685c9b98e0288333afc22742211506a8