### PR TITLE
Fix axes for caked 2D view

### DIFF
--- a/main.py
+++ b/main.py
@@ -1145,6 +1145,14 @@ def do_update():
         caked_img = sim_res2.intensity
         image_display.set_data(caked_img)
         image_display.set_clim(vmin_caked_var.get(), vmax_caked_var.get())
+        image_display.set_extent([
+            float(sim_res2.radial[0]),
+            float(sim_res2.radial[-1]),
+            float(sim_res2.azimuthal[-1]),
+            float(sim_res2.azimuthal[0]),
+        ])
+        ax.set_xlabel('2θ (degrees)')
+        ax.set_ylabel('φ (degrees)')
         ax.set_title('2D Caked Integration')
         background_display.set_visible(False)
     else:
@@ -1154,6 +1162,9 @@ def do_update():
         else:
             image_display.set_data(np.zeros((image_size, image_size)))
         image_display.set_clim(0, vmax_var.get())
+        image_display.set_extent([0, image_size, image_size, 0])
+        ax.set_xlabel('X (pixels)')
+        ax.set_ylabel('Y (pixels)')
         ax.set_title('Simulated Diffraction Pattern')
         background_display.set_visible(background_visible)
         


### PR DESCRIPTION
## Summary
- update display axes when 2D caking is enabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea269fc08833386a0a2046f0a5e2e