### PR TITLE
Add status square to GUI

### DIFF
--- a/ra_sim/gui/main_app.py
+++ b/ra_sim/gui/main_app.py
@@ -39,6 +39,11 @@ def main():
     canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=True)
     canvas.draw()
 
+    # Status indicator square
+    status_canvas = tk.Canvas(root, width=40, height=40, highlightthickness=0)
+    status_rect = status_canvas.create_rectangle(0, 0, 40, 40, fill="green", outline="")
+    status_canvas.pack(side=tk.RIGHT, padx=10, pady=10)
+
     # Loading indicator shown during long computations
     loading_label = ttk.Label(root, text="Loading...", font=("Helvetica", 12))
 
@@ -139,6 +144,7 @@ def main():
                 ax.imshow(image, cmap='turbo', vmin=0, vmax=1e5)
                 canvas.draw_idle()
                 loading_label.pack_forget()
+                status_canvas.itemconfig(status_rect, fill="green")
                 is_computing = False
                 if pending_update:
                     pending_update = False
@@ -148,6 +154,7 @@ def main():
 
         is_computing = True
         loading_label.pack(side=tk.BOTTOM, pady=5)
+        status_canvas.itemconfig(status_rect, fill="red")
 
         theta_initial = theta_initial_var.get()
         gamma = gamma_var.get()


### PR DESCRIPTION
## Summary
- add colored status square to Tkinter GUI
- switch the square from green to red while computations run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ecc6225408333b5938c1562f7441a