### PR TITLE
Fix slider toggle visibility

### DIFF
--- a/tests/Diffuse/diffuse_with_cif_polytype_toggle.py
+++ b/tests/Diffuse/diffuse_with_cif_polytype_toggle.py
@@ -263,17 +263,6 @@ b.on_clicked(lambda _: (
     ax.set_yscale('linear' if ax.get_yscale()=='log' else 'log'),
     refresh()
 ))
-# ─── create & store m-slider ────────────────────────────────────────────────
-m_slider = make_slider(
-    [0.25, ys[0], 0.65, 0.03],
-    'm index',
-    min(ALLOWED_M), max(ALLOWED_M),
-    state['m'],
-    ALLOWED_M,
-    lambda v: (state.update(m=int(v)), compute_components(), refresh())
-)
-# also keep it in _sliders for uniform handling if you like
-_sliders.append(m_slider)
 
 
 def toggle_mode(_):


### PR DESCRIPTION
## Summary
- remove duplicate m-slider from diffuse_with_cif_polytype_toggle.py
- keep single slider so HK mode hides it correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef536224483339d49deff70ef74af