### PR TITLE
Fix scatter figure UI responsiveness

### DIFF
--- a/tests/Diffuse/diffuse_with_cif_polytype_toggle.py
+++ b/tests/Diffuse/diffuse_with_cif_polytype_toggle.py
@@ -489,7 +489,7 @@ def plot_scatter(_):
 
     # Leave room for the control widgets to remain responsive
     plt.subplots_adjust(right=0.78)
-    plt.show()
+    plt.show(block=False)
 
 def compare_numeric(_):
     df = _last_df if _last_df is not None else _build_bragg_dataframe()


### PR DESCRIPTION
## Summary
- use `plt.show(block=False)` when displaying the scatter plot to avoid freezing the Tk event loop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862c5c6f5408333a854a4a07ad8b225