### PR TITLE
Implement epsilon-based HT limits

### DIFF
--- a/ra_sim/utils/stacking_fault.py
+++ b/ra_sim/utils/stacking_fault.py
@@ -105,6 +105,26 @@ def _abc(p, h, k):
     ψ = np.arctan2(imag, real)
     return f, ψ, δ
 
+def R_exact(f, theta):
+    """Return the Hendricks–Teller ratio ``R(f, θ)`` exactly."""
+    import numpy as np
+    return (1 - f * f) / (1 + f * f - 2 * f * np.cos(theta))
+
+
+def R_near_perfect(theta, eps):
+    """Series expansion of ``R`` for ``f = 1 - ε`` (``ε`` small)."""
+    import numpy as np
+    if np.isclose(np.mod(theta, 2 * np.pi), 0.0):
+        return 2.0 / eps - 1.0
+    denom = 1.0 - np.cos(theta)
+    return (eps / denom) * (1.0 - 0.5 * eps)
+
+
+def R_quasi_random(theta, eps):
+    """Series expansion of ``R`` for ``f = ε`` (``ε`` small)."""
+    import numpy as np
+    return 1.0 + 2.0 * eps * np.cos(theta)
+
 def _I_inf(L, p, h, k, F2):
     import numpy as np
     f, ψ, δ = _abc(p, h, k)

--- a/tests/test_ht_limiting_cases.py
+++ b/tests/test_ht_limiting_cases.py
@@ -1,0 +1,33 @@
+import pytest
+
+from ra_sim.utils.stacking_fault import R_exact, R_near_perfect, R_quasi_random
+
+
+def test_R_exact_symmetry():
+    f = 0.75
+    th = 0.3
+    assert R_exact(f, th) == pytest.approx(R_exact(f, -th))
+
+
+def test_near_perfect_matches_exact_nonzero_theta():
+    eps = 1e-3
+    th = 0.5
+    exact = R_exact(1 - eps, th)
+    approx = R_near_perfect(th, eps)
+    assert approx == pytest.approx(exact, rel=1e-3)
+
+
+def test_near_perfect_theta_zero():
+    eps = 1e-4
+    th = 0.0
+    exact = R_exact(1 - eps, th)
+    approx = R_near_perfect(th, eps)
+    assert approx == pytest.approx(exact, rel=1e-3)
+
+
+def test_quasi_random_matches_exact():
+    eps = 1e-3
+    th = 0.6
+    exact = R_exact(eps, th)
+    approx = R_quasi_random(th, eps)
+    assert approx == pytest.approx(exact, rel=1e-3)


### PR DESCRIPTION
## Summary
- add near-perfect and quasi-random expansions for the Hendricks–Teller ratio
- verify symmetry and accuracy of the new functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686432a3e61c8333b4d1d0d7b3b232a7