### PR TITLE
Add z-value slider to HT viewer

### DIFF
--- a/tests/Diffuse/diffuse_with_cif_polytype_toggle.py
+++ b/tests/Diffuse/diffuse_with_cif_polytype_toggle.py
@@ -71,6 +71,7 @@ BUNDLE = Path(getattr(sys, "_MEIPASS", Path(__file__).parent))
 CIF_2H = BUNDLE / "PbI2_2H.cif"
 CIF_6H = BUNDLE / "PbI2_6H.cif"
 C_2H, C_6H = map(c_from_cif, map(str, (CIF_2H, CIF_6H)))
+Z_DEFAULT = C_2H / C_6H
 
 # ───────── constants ─────────
 LAMBDA = 1.5406  # Å   (Cu Kα1)
@@ -220,7 +221,8 @@ defaults = {
     "I3": None,
     "L_lo": 1.0,
     "L_hi": L_MAX,
-    "z_val": 1 / 3,
+    # Use the ratio of lattice parameters from the CIFs as the phase scale
+    "z_val": Z_DEFAULT,
 }
 state = defaults.copy()
 
@@ -869,7 +871,7 @@ def make_slider(rect, label, vmin, vmax, val, valstep, cb):
 
 
 # ℓ-range slider
-ax_range = plt.axes([0.25, 0.05, 0.65, 0.03])
+ax_range = plt.axes([0.25, 0.05, 0.45, 0.03])
 rs = RangeSlider(
     ax_range, "ℓ range", 0, L_MAX, valinit=(state["L_lo"], state["L_hi"]), valstep=0.1
 )
@@ -969,14 +971,14 @@ make_slider(
     lambda v: (state.update(w2=v), refresh()),
 )
 
-# z value slider for main HT simulation
+# z value slider for main HT simulation (to the right of the ℓ-range slider)
 make_slider(
-    [0.25, 0.36, 0.65, 0.03],
+    [0.72, 0.05, 0.20, 0.03],
     "z value",
     0.1,
     1.0,
     state["z_val"],
-    0.01,
+    1e-4,
     lambda v: (state.update(z_val=v), compute_components(), refresh()),
 )
 


### PR DESCRIPTION
## Summary
- add `z_val` to GUI state in `diffuse_with_cif_polytype_toggle`
- use `z_val` as the phase scale for the main p slider
- add a new slider widget to control `z_val`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864766897348333a9b5b92ceae1e99c