### PR TITLE
Add iodine z slider

### DIFF
--- a/tests/Diffuse/diffuse_with_cif_polytype_toggle.py
+++ b/tests/Diffuse/diffuse_with_cif_polytype_toggle.py
@@ -162,10 +162,14 @@ L_GRID = np.linspace(0, L_MAX, N_L)
 # precompute |F|² for 2H lattice (single-layer form factor)
 F2_cache_2H: dict[tuple[int, int], np.ndarray] = {}
 
+# store contributions that don't change with iodine z
+_FIXED_PART: dict[tuple[int, int], np.ndarray] = {}
+# store the coefficient multiplied by exp(2πi * ℓ * z) for iodine sites
+_IODINE_FACTOR: dict[tuple[int, int], np.ndarray] = {}
 
-def compute_F2_cache(i_z: float) -> None:
-    """Recalculate ``F2_cache_2H`` for a given iodine ``z`` position."""
-    F2_cache_2H.clear()
+
+def _precompute_F_parts() -> None:
+    """Precompute constant and iodine-dependent scattering contributions."""
     for pairs in HK_BY_M.values():
         for h, k in pairs:
             Q_2h = (
@@ -176,24 +180,29 @@ def compute_F2_cache(i_z: float) -> None:
                     + (L_GRID**2) / C_2H**2
                 )
             )
-            phases_2h = np.array(
-                [
-                    np.exp(
-                        2j
-                        * np.pi
-                        * (
-                            h * x
-                            + k * y
-                            + L_GRID * ((i_z if sym.startswith("I") else z) / 3)
-                        )
-                    )
-                    for x, y, z, sym in SITES_2H
-                ]
-            )
-            coeffs_2h = np.array([f_comp(sym, Q_2h) for *_, sym in SITES_2H])
-            F2_cache_2H[(h, k)] = np.abs((coeffs_2h * phases_2h).sum(axis=0)) ** 2
+            fixed = np.zeros_like(L_GRID, dtype=complex)
+            factor = np.zeros_like(L_GRID, dtype=complex)
+            for x, y, z, sym in SITES_2H:
+                f = f_comp(sym, Q_2h)
+                phase_xy = np.exp(2j * np.pi * (h * x + k * y))
+                if sym.startswith("I"):
+                    factor += f * phase_xy
+                else:
+                    fixed += f * phase_xy * np.exp(2j * np.pi * L_GRID * (z / 3))
+            _FIXED_PART[(h, k)] = fixed
+            _IODINE_FACTOR[(h, k)] = factor
 
 
+def compute_F2_cache(i_z: float) -> None:
+    """Recalculate ``F2_cache_2H`` for a given iodine ``z`` position."""
+    phase_z = np.exp(2j * np.pi * L_GRID * (i_z / 3))
+    F2_cache_2H.clear()
+    for key in _FIXED_PART:
+        total = _FIXED_PART[key] + _IODINE_FACTOR[key] * phase_z
+        F2_cache_2H[key] = np.abs(total) ** 2
+
+
+_precompute_F_parts()
 compute_F2_cache(DEFAULT_I_Z)
 
 # Hendricks–Teller infinite stacking


### PR DESCRIPTION
## Summary
- expose iodine z value from CIF and provide slider to adjust it
- recompute 2H single-layer form factor when iodine z changes
- default to z=0.2675 from `PbI2_2H.cif`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864b39e48b483338d721e70b86c12cf