### PR TITLE
Fix F2 lookup for each HK pair

### DIFF
--- a/tests/Diffuse/diffuse_with_cif_polytype_toggle.py
+++ b/tests/Diffuse/diffuse_with_cif_polytype_toggle.py
@@ -284,7 +284,11 @@ def compute_components():
     if state["mode"] == "hk":  # no symmetry weight
         counts = {(h, k): 1 for h, k in pairs}
     else:  # hexagonal degeneracy
-        counts = Counter((abs(h), abs(k)) for h, k in pairs)
+        # Keep the sign for each (h,k) pair so the correct single-layer
+        # form factor is used for ``I_inf``.  Each pair appears once in
+        # ``pairs`` so the Counter simply enables potential future
+        # weighting without dropping the sign information.
+        counts = Counter(pairs)
 
     def comp(p, phi_scale):
         return sum(


### PR DESCRIPTION
## Summary
- ensure each (h,k) pair keeps its sign when computing component intensities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864c430eaa48333bf86b0a8346ad9d9